### PR TITLE
fix(deploy): verify the alias, and make rollback prove it worked

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,7 +199,10 @@ jobs:
       - name: Require deployment credentials
         shell: bash
         run: |
-          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+          # PRODUCTION_WEB_URL is required, not optional: it is the origin the
+          # release is verified against. Without it a deploy cannot be proven,
+          # and an unprovable deploy is what let a broken release look fine.
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID PRODUCTION_WEB_URL; do
             if [[ -z "${!name}" ]]; then
               echo "::error::$name is required to deploy to production."
               exit 1
@@ -246,18 +249,24 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "Deployed $url"
 
-      - name: Verify the new deployment
-        env:
-          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: node scripts/verify-deployment.mjs "${{ steps.deploy.outputs.url }}"
-
-      # The deployment URL can be healthy while the production alias still points
-      # somewhere else. Users hit the alias, so that is what has to be green.
+      # The production alias is the gate, because it is what users actually hit.
+      # EXPECTED_RELEASE makes this prove the NEW build is serving: a healthy
+      # response from the previous deployment would otherwise pass.
       - name: Verify the production domain
-        if: env.PRODUCTION_WEB_URL != ''
+        env:
+          EXPECTED_RELEASE: ${{ github.sha }}
+        run: node scripts/verify-deployment.mjs "$PRODUCTION_WEB_URL"
+
+      # Best-effort only. Deployment URLs sit behind Deployment Protection,
+      # which serves an HTML login page instead of the app, so this cannot be a
+      # gate — it failed the first real release for exactly that reason while
+      # the alias above was healthy the whole time.
+      - name: Probe the deployment URL directly
+        continue-on-error: true
         env:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-        run: node scripts/verify-deployment.mjs "$PRODUCTION_WEB_URL"
+          DEPLOY_VERIFY_TIMEOUT_MS: "30000"
+        run: node scripts/verify-deployment.mjs "${{ steps.deploy.outputs.url }}"
 
       # Vercel deployments are immutable, so rollback is an alias switch back to
       # the previous production deployment — fast, and safe to automate. It is
@@ -266,18 +275,34 @@ jobs:
       - name: Roll back to the previous production deployment
         if: failure() && steps.deploy.outcome == 'success'
         shell: bash
+        env:
+          # Proves the alias moved OFF this release. `vercel rollback` has been
+          # observed exiting 0 without changing anything, and a rollback that
+          # reports success without acting is worse than none — you stand down
+          # believing production was reverted.
+          REJECTED_RELEASE: ${{ github.sha }}
         run: |
           echo "::warning::Verification failed. Rolling back to the previous production deployment."
-          if vercel rollback --yes --timeout 5m --token="$VERCEL_TOKEN"; then
+          rollback_ok=0
+          vercel rollback --yes --timeout 5m --token="$VERCEL_TOKEN" || rollback_ok=$?
+
+          if node scripts/verify-deployment.mjs "$PRODUCTION_WEB_URL"; then
             {
               echo "### ↩️ Rolled back"
               echo ""
-              echo "\`${{ steps.deploy.outputs.url }}\` failed verification and the"
-              echo "production alias was returned to the previous deployment."
-              echo ""
-              echo "Confirm in the Vercel dashboard before standing down."
+              echo "\`${{ steps.deploy.outputs.url }}\` failed verification. The"
+              echo "production alias no longer serves \`${{ github.sha }}\` and the"
+              echo "origin is healthy."
             } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "::error::Automatic rollback FAILED. Use Instant Rollback in the Vercel dashboard now."
+            {
+              echo "### 🚨 Rollback did NOT take effect"
+              echo ""
+              echo "\`vercel rollback\` exited \`${rollback_ok}\`, but the production"
+              echo "domain is still serving \`${{ github.sha }}\` or is unhealthy."
+              echo ""
+              echo "**Use Instant Rollback in the Vercel dashboard now.**"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Rollback did not take effect. Use Instant Rollback in the Vercel dashboard now."
             exit 1
           fi

--- a/scripts/verify-deployment.mjs
+++ b/scripts/verify-deployment.mjs
@@ -12,6 +12,16 @@ const healthUrl = new URL("/health", baseUrl);
 const deadline = Date.now() + timeoutMs;
 const automationBypassSecret =
   process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim();
+
+// When set, the origin must be serving exactly this release. "Healthy" alone
+// cannot tell a new deployment from the old one still on the alias, which is
+// the difference between a deploy that landed and one that silently did not.
+const expectedRelease = process.env.EXPECTED_RELEASE?.trim();
+
+// When set, the origin must NOT be serving this release. Used after a rollback
+// to prove the alias actually moved off the bad deployment.
+const rejectedRelease = process.env.REJECTED_RELEASE?.trim();
+
 let lastFailure = "No request attempted";
 
 while (Date.now() < deadline) {
@@ -30,22 +40,41 @@ while (Date.now() < deadline) {
     try {
       body = JSON.parse(responseText);
     } catch {
-      lastFailure = `HTTP ${response.status}: expected JSON, received ${response.headers.get("content-type") || "unknown content type"}`;
+      // An HTML body on a deployment URL is almost always Vercel's Deployment
+      // Protection login page rather than the app. Say so, because "expected
+      // JSON" on its own sends people looking at the wrong thing.
+      const contentType =
+        response.headers.get("content-type") || "unknown content type";
+      const looksProtected =
+        contentType.includes("text/html") && !automationBypassSecret;
+      lastFailure =
+        `HTTP ${response.status}: expected JSON, received ${contentType}` +
+        (looksProtected
+          ? " — likely Deployment Protection; set VERCEL_AUTOMATION_BYPASS_SECRET or verify the production domain instead"
+          : "");
       await new Promise((resolve) => setTimeout(resolve, 5_000));
       continue;
     }
-    if (
+    const healthy =
       response.ok &&
       body.status === "ok" &&
       body.service === "apsaratalent-web" &&
-      body.apiBaseUrlConfigured === true
-    ) {
+      body.apiBaseUrlConfigured === true;
+
+    if (healthy && expectedRelease && body.release !== expectedRelease) {
+      // Healthy, but still the previous build. The alias has not switched yet;
+      // keep polling rather than declaring success on the old deployment.
+      lastFailure = `serving release ${body.release || "unknown"}, expected ${expectedRelease}`;
+    } else if (healthy && rejectedRelease && body.release === rejectedRelease) {
+      lastFailure = `still serving the rolled-back release ${rejectedRelease}`;
+    } else if (healthy) {
       console.log(
         `Verified ${healthUrl} (${body.service}, release=${body.release || "unknown"})`,
       );
       process.exit(0);
+    } else {
+      lastFailure = `HTTP ${response.status}: ${JSON.stringify(body)}`;
     }
-    lastFailure = `HTTP ${response.status}: ${JSON.stringify(body)}`;
   } catch (error) {
     lastFailure = error instanceof Error ? error.message : String(error);
   }


### PR DESCRIPTION
Fixes two defects that the first real release through the new deploy job exposed. Production was healthy the whole time — the job reported failure on a success, and its rollback reported success on a no-op.

## 1. Verification targeted the wrong URL

The job verified the **deployment-specific URL**, which sits behind Vercel Deployment Protection. Protection answers with an HTML login page, so the verifier could never see JSON:

```
Error: Deployment did not become healthy within 180000ms:
HTTP 200: expected JSON, received text/html
```

The **production alias** — what users actually hit — was serving correctly throughout, but was only checked when `PRODUCTION_WEB_URL` happened to be set, and it wasn't.

Now:
- the alias is the gate, and `PRODUCTION_WEB_URL` is **required** (a deploy that cannot be proven cannot pass)
- `EXPECTED_RELEASE` asserts the **new build** is the one serving. Without it, a healthy response from the *previous* deployment passes — which is exactly how a deploy that never landed looks green
- the deployment URL is still probed, but `continue-on-error`, since protection makes it unusable as a gate

## 2. Rollback reported success without acting

`vercel rollback` exited 0 while the alias never moved. The step now re-checks the origin with `REJECTED_RELEASE` and fails loudly if production still serves the bad release.

A rollback that reports success without acting is worse than no rollback: you stand down believing production was reverted.

## Verification

Exercised against live production (read-only):

| Case | Result |
| --- | --- |
| correct release expected | passes |
| wrong release expected | fails — "serving release X, expected Y" |
| still serving rejected release | fails — the rollback-lied detector |
| moved off rejected release | passes |
| protected deployment URL | now names Deployment Protection instead of "expected JSON" |

`lint` clean, 466 unit tests pass.