### PR TITLE
fix: close CodeQL's five findings on the first scan of this repo

### DIFF
--- a/components/notification/notification-base-card/index.tsx
+++ b/components/notification/notification-base-card/index.tsx
@@ -66,7 +66,7 @@ export default function NotificationBaseCard(
         <div
           className={cn(
             "absolute bottom-0 left-0 top-0 w-1 transition-all duration-300",
-            unreadColor.replace("bg-", "bg-"), // Ensure it's a bg class
+            unreadColor,
           )}
         />
       )}

--- a/stores/apis/auth/socials/facebook-login.store.ts
+++ b/stores/apis/auth/socials/facebook-login.store.ts
@@ -49,7 +49,6 @@ type TFacebookLoginState = {
 const BACKEND_ORIGIN = new URL(API_AUTH_SOCIAL_FACEBOOK_URL).origin;
 const FRONTEND_ORIGIN =
   typeof window !== "undefined" ? window.location.origin : "";
-const ALLOWED_ORIGINS = new Set([BACKEND_ORIGIN, FRONTEND_ORIGIN]);
 
 // Shared Finish Logic
 const FINISH_LOGIN = (data: TFacebookLoginResponse) => {
@@ -129,8 +128,21 @@ export const useFacebookLoginStore = create<TFacebookLoginState>((set) => ({
     let messageReceived = false;
 
     const handleMessage = (ev: MessageEvent<TFacebookLoginResponse>) => {
-      // Origin check: accept messages from backend or frontend
-      if (!ALLOWED_ORIGINS.has(ev.origin)) {
+      // Only the backend callback page and this app may drive login.
+      // Written as explicit comparisons rather than a Set lookup: the
+      // behaviour is identical, but CodeQL's js/missing-origin-check does not
+      // recognise `Set.has(ev.origin)` as an origin check and reported these
+      // four handlers as unguarded.
+      //
+      // The empty-origin guard is not cosmetic. `ev.origin` is "" for opaque
+      // origins (sandboxed iframes, file://, data:), and FRONTEND_ORIGIN is
+      // also "" whenever this module is evaluated without a window — so
+      // without it those two could compare equal and admit a message from an
+      // origin the browser refused to name.
+      if (
+        !ev.origin ||
+        (ev.origin !== BACKEND_ORIGIN && ev.origin !== FRONTEND_ORIGIN)
+      ) {
         console.warn("Ignored message from unexpected origin:", ev.origin);
         return;
       }

--- a/stores/apis/auth/socials/github-login.store.ts
+++ b/stores/apis/auth/socials/github-login.store.ts
@@ -47,7 +47,6 @@ type TGithubLoginState = {
 const BACKEND_ORIGIN = new URL(API_AUTH_SOCIAL_GITHUB_URL).origin;
 const FRONTEND_ORIGIN =
   typeof window !== "undefined" ? window.location.origin : "";
-const ALLOWED_ORIGINS = new Set([BACKEND_ORIGIN, FRONTEND_ORIGIN]);
 
 // Shared Finish Logic
 const FINISH_LOGIN = (data: TGithubLoginResponse) => {
@@ -125,8 +124,21 @@ export const useGithubLoginStore = create<TGithubLoginState>((set) => ({
     let messageReceived = false;
 
     const handleMessage = (ev: MessageEvent<TGithubLoginResponse>) => {
-      // Origin check: accept messages from backend or frontend
-      if (!ALLOWED_ORIGINS.has(ev.origin)) {
+      // Only the backend callback page and this app may drive login.
+      // Written as explicit comparisons rather than a Set lookup: the
+      // behaviour is identical, but CodeQL's js/missing-origin-check does not
+      // recognise `Set.has(ev.origin)` as an origin check and reported these
+      // four handlers as unguarded.
+      //
+      // The empty-origin guard is not cosmetic. `ev.origin` is "" for opaque
+      // origins (sandboxed iframes, file://, data:), and FRONTEND_ORIGIN is
+      // also "" whenever this module is evaluated without a window — so
+      // without it those two could compare equal and admit a message from an
+      // origin the browser refused to name.
+      if (
+        !ev.origin ||
+        (ev.origin !== BACKEND_ORIGIN && ev.origin !== FRONTEND_ORIGIN)
+      ) {
         console.warn("Ignored message from unexpected origin:", ev.origin);
         return;
       }

--- a/stores/apis/auth/socials/google-login.store.ts
+++ b/stores/apis/auth/socials/google-login.store.ts
@@ -49,7 +49,6 @@ type TGoogleLoginState = {
 const BACKEND_ORIGIN = new URL(API_AUTH_SOCIAL_GOOGLE_URL).origin;
 const FRONTEND_ORIGIN =
   typeof window !== "undefined" ? window.location.origin : "";
-const ALLOWED_ORIGINS = new Set([BACKEND_ORIGIN, FRONTEND_ORIGIN]);
 
 const FINISH_LOGIN = (data: TGoogleLoginResponse) => {
   if (!data || data.type !== "GOOGLE_AUTH_SUCCESS") {
@@ -128,8 +127,21 @@ export const useGoogleLoginStore = create<TGoogleLoginState>((set) => ({
     let messageReceived = false;
 
     const handleMessage = (ev: MessageEvent<TGoogleLoginResponse>) => {
-      // Origin check: accept messages from backend or frontend
-      if (!ALLOWED_ORIGINS.has(ev.origin)) {
+      // Only the backend callback page and this app may drive login.
+      // Written as explicit comparisons rather than a Set lookup: the
+      // behaviour is identical, but CodeQL's js/missing-origin-check does not
+      // recognise `Set.has(ev.origin)` as an origin check and reported these
+      // four handlers as unguarded.
+      //
+      // The empty-origin guard is not cosmetic. `ev.origin` is "" for opaque
+      // origins (sandboxed iframes, file://, data:), and FRONTEND_ORIGIN is
+      // also "" whenever this module is evaluated without a window — so
+      // without it those two could compare equal and admit a message from an
+      // origin the browser refused to name.
+      if (
+        !ev.origin ||
+        (ev.origin !== BACKEND_ORIGIN && ev.origin !== FRONTEND_ORIGIN)
+      ) {
         console.warn("Ignored message from unexpected origin:", ev.origin);
         return;
       }

--- a/stores/apis/auth/socials/linkedin-login.store.ts
+++ b/stores/apis/auth/socials/linkedin-login.store.ts
@@ -49,7 +49,6 @@ type TLinkedInLoginState = {
 const BACKEND_ORIGIN = new URL(API_AUTH_SOCIAL_LINKEDIN_URL).origin;
 const FRONTEND_ORIGIN =
   typeof window !== "undefined" ? window.location.origin : "";
-const ALLOWED_ORIGINS = new Set([BACKEND_ORIGIN, FRONTEND_ORIGIN]);
 
 // Shared Finish Logic
 const FINISH_LOGIN = (data: TLinkedInLoginResponse) => {
@@ -129,8 +128,21 @@ export const useLinkedInLoginStore = create<TLinkedInLoginState>((set) => ({
     let messageReceived = false;
 
     const handleMessage = (ev: MessageEvent<TLinkedInLoginResponse>) => {
-      // Origin check: accept messages from backend or frontend
-      if (!ALLOWED_ORIGINS.has(ev.origin)) {
+      // Only the backend callback page and this app may drive login.
+      // Written as explicit comparisons rather than a Set lookup: the
+      // behaviour is identical, but CodeQL's js/missing-origin-check does not
+      // recognise `Set.has(ev.origin)` as an origin check and reported these
+      // four handlers as unguarded.
+      //
+      // The empty-origin guard is not cosmetic. `ev.origin` is "" for opaque
+      // origins (sandboxed iframes, file://, data:), and FRONTEND_ORIGIN is
+      // also "" whenever this module is evaluated without a window — so
+      // without it those two could compare equal and admit a message from an
+      // origin the browser refused to name.
+      if (
+        !ev.origin ||
+        (ev.origin !== BACKEND_ORIGIN && ev.origin !== FRONTEND_ORIGIN)
+      ) {
         console.warn("Ignored message from unexpected origin:", ev.origin);
         return;
       }


### PR DESCRIPTION
CodeQL was added in #116 and this is the first triage of what it found:
four js/missing-origin-check and one js/identity-replacement, all medium.

## The four origin checks were already there

Each social login store opens an OAuth popup and receives the result by
postMessage, and each already gated on an allowlist:

  const ALLOWED_ORIGINS = new Set([BACKEND_ORIGIN, FRONTEND_ORIGIN]);
  if (!ALLOWED_ORIGINS.has(ev.origin)) return;

That is a correct check. CodeQL's js/missing-origin-check does not
recognise `Set.has(ev.origin)` as one, so it reported all four handlers
as unguarded. Rewritten as explicit comparisons — identical behaviour,
and the tool now agrees rather than the finding being dismissed with a
note nobody reads.

## One real gap found while confirming that

`ev.origin` is the empty string for opaque origins — sandboxed iframes,
file://, data:. FRONTEND_ORIGIN is ALSO "" whenever the module is
evaluated without a window, since it reads window.location.origin behind
a typeof guard. Those two comparing equal would admit a message from an
origin the browser deliberately refused to name.

Narrow, but it is a real hole in an authentication path, and the
rewrite would have preserved it. `!ev.origin` now rejects it outright.

## The identity replacement was dead code

  unreadColor.replace("bg-", "bg-") // Ensure it's a bg class

It replaces the prefix with itself, so it ensures nothing. Every value
already carries the prefix — the default is "bg-primary" and the four
callers pass "bg-teal-500", "bg-pink-500", "bg-blue-500",
"bg-green-500" — and the same variable is used raw twenty lines further
down. Removed rather than repaired: there is no case it was guarding.

Verified: lint, typecheck, test:ci and next build all exit 0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
