### PR TITLE
chore: stop dependabot re-offering eslint-config-next majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,14 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # eslint-config-next major must move with `next` itself. Offered on its
+      # own (PR #122: 15.5.22 -> 16.3.0 against next@15) it only fails config
+      # validation, which is not fixable from our side. Drop this entry as part
+      # of the Next 16 upgrade.
+      - dependency-name: eslint-config-next
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Follow-up to closing #122.

`eslint-config-next` 16.x targets Next 16, but this repo is on `next@^15.5.22`. Offered on its own, it fails config validation with `TypeError: Converting circular structure to JSON` inside `@eslint/eslintrc` — a version mismatch, not something fixable in our config.

Without an ignore rule dependabot re-opens the same dead end every Monday. Scoped to **majors only**, so patch/minor fixes for this package still come through. The entry should be dropped as part of the Next 16 upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)